### PR TITLE
Documentation on producing JSON inputs

### DIFF
--- a/docs/Usage_DecoderAPI.md
+++ b/docs/Usage_DecoderAPI.md
@@ -1,16 +1,122 @@
+## 🔎 Using the Coriolis Decoder
+
 The decoder endpoint will be available by default on <http://localhost:8080/argo-toolbox/api/decoder> (POST method).
 
 The endpoint to decode files for a specific float will be <http://localhost:8080/argo-toolbox/api/decoder/decode_float/{WMONUM}>, with the float's respective WMONUM inserted.
 The files to decode need to be included in the body of a `multipart/form-data` type request alongside the metadata information about the float and optional configuration overrides.
 
-```bash
-curl -X 'POST' TBD...
-```
-
-#### JupyterLab example
+### 🪐 JupyterLab examples
 
 The JupyterLab instance provided by this repository is pre-configured with a notebook demonstrating usage of the Decoder API.
 See the [JupyterLab usage instructions](Usage_JupyterLab.md) for details on how to access the instance.
+
+### Constructing Float Configuration Information
+
+Metadata and configuration information about the float whose data is to be decoded must be sent to the API as part of the request.
+This is the same information contained in the float metadata file and float decoder configuration files (often named meta.json and info.json).
+The configuration information is required by the decoder. The metadata information will be copied into the Meta NetCDF file generated during decoding.
+Please see the [Coriolis Decoder Manual](https://github.com/euroargodev/Coriolis-data-processing-chain-for-Argo-floats/tree/main/decArgo_doc/decoder_user_manual)
+for information on how to populate this information.
+
+#### Reading Float Configuration Information from existing JSON files (Python)
+
+```python
+# Open the info and meta JSONS for the float we want to decode.
+with open(r"path/to/info.json") as file:
+    float_info = json.loads(file.read())
+
+with open(r"path/to/meta.json") as file:
+    meta_info = json.loads(file.read())
+```
+
+#### Manually Constructing Float Configuration Information (Python)
+
+```python
+import json
+float_info = {
+    "WMO": "6903014",
+    "PTT": "300234068508780",
+    "FLOAT_TYPE": "PROVOR",
+    # add further float information
+}
+
+meta_info = {
+    "ARGO_USER_MANUAL_VERSION": "3.1",
+    "PLATFORM_NUMBER": "6903014",
+    "PTT": "850878",
+    "IMEI": "300234068508780",
+    # add further metadata information
+}
+
+float_metadata = json.dumps({
+    "float_info": float_info,
+    "float_metadata_info": meta_info
+})
+```
+
+#### Setting Decoder Options
+
+Additional decoder input parameters can be provided to the Decoder API via an  optional `configuration_override` parameter.
+This accepts the parameters usually contained in a decoder config json file, such as in the examples found here: 
+
+https://github.com/euroargodev/Coriolis-data-processing-chain-for-Argo-floats/tree/main/decArgo_soft/config/configuration_sample_files
+
+```python
+# Example extra args, used to pass to the decoder and override the default configuration.
+extra_args = {
+    "DIR_OUTPUT_XML_FILE": "/mnt/data/output/xml/",
+}
+```
+
+### Example API Requests
+
+##### Python
+```python
+from pathlib import Path
+import requests
+import json
+
+url = "http://localhost:8080/argo-toolbox/api/decoder/decode_float/6903014"
+file_dir = r"path/to/source/files"
+
+# Source files
+files = [
+    ("files", (str(Path(file_path).name), open(file_path, "rb"), "text/plain"))
+    for file_path in Path(file_dir).glob("*.txt")
+]
+
+# Float configuration information
+with open(r"mockfiles_6903014/info_json.json") as file:
+    float_info = json.loads(file.read())
+
+with open(r"mockfiles_6903014/meta_info.json") as file:
+    meta_info = json.loads(file.read())
+data = {
+    "float_metadata": json.dumps(
+        {
+            "float_info": float_info,
+            "float_meta_info": meta_info,
+        }
+    ),
+    "configuration_override": json.dumps(extra_args),  # optional
+}
+
+# API request
+response = requests.post(url, files=files, data=data)
+```
+
+##### CURL 
+```bash
+curl -X "POST" \
+  "http://localhost:8080/argo-toolbox/api/decoder/decode_float/6903014" \
+  -H "accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -F 'files=@co_20190527T085840Z_300234068508780_000001_000000_18220.txt;type=text/plain' \
+  -F 'float_metadata={"float_info":{"WMO":"6903014","PTT":"300234068508780","FLOAT_TYPE":"PROVOR","DECODER_VERSION":"5.45", ...},"float_meta_info":{"ARGO_USER_MANUAL_VERSION":"3.1","PLATFORM_NUMBER":"6903014","PTT":"850878","IMEI":"300234068508780", ...}}' \
+  -F 'configuration_override={"DIR_OUTPUT_XML_FILE":"/mnt/data/output/xml/"}'
+```
+
+
 
 
 ### 💻 API Usage Examples

--- a/docs/Usage_DecoderAPI.md
+++ b/docs/Usage_DecoderAPI.md
@@ -38,7 +38,7 @@ float_info = {
     "WMO": "6903014",
     "PTT": "300234068508780",
     "FLOAT_TYPE": "PROVOR",
-    # add further float information
+    # add further float configuration information
 }
 
 meta_info = {
@@ -51,7 +51,7 @@ meta_info = {
 
 float_metadata = json.dumps({
     "float_info": float_info,
-    "float_metadata_info": meta_info
+    "float_meta_info": meta_info
 })
 ```
 

--- a/docs/Usage_DecoderAPI.md
+++ b/docs/Usage_DecoderAPI.md
@@ -14,6 +14,7 @@ See the [JupyterLab usage instructions](Usage_JupyterLab.md) for details on how 
 
 Metadata and configuration information about the float whose data is to be decoded must be sent to the API as part of the request.
 This is the same information contained in the float metadata file and float decoder configuration files (often named meta.json and info.json).
+
 The configuration information is required by the decoder. The metadata information will be copied into the Meta NetCDF file generated during decoding.
 Please see the [Coriolis Decoder Manual](https://github.com/euroargodev/Coriolis-data-processing-chain-for-Argo-floats/tree/main/decArgo_doc/decoder_user_manual)
 for information on how to populate this information.
@@ -54,7 +55,7 @@ float_metadata = json.dumps({
 })
 ```
 
-#### Setting Decoder Options
+### Setting Decoder Options
 
 Additional decoder input parameters can be provided to the Decoder API via an  optional `configuration_override` parameter.
 This accepts the parameters usually contained in a decoder config json file, such as in the examples found here: 

--- a/jupyter/examples/notebooks/decoder-matlab.ipynb
+++ b/jupyter/examples/notebooks/decoder-matlab.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d5851948-6f51-44d9-9eb3-6c61e112ab49",
    "metadata": {},
    "outputs": [],
@@ -96,10 +96,102 @@
   },
   {
    "cell_type": "markdown",
+   "id": "82ced23e-e0e3-4b68-af1e-d52a20af5249",
+   "metadata": {},
+   "source": [
+    "# Float configuration and metadata - Option 1: Construct manually"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae1a8c16-9002-4f88-b00c-843b17701e3d",
+   "metadata": {},
+   "source": [
+    "See the [Coriolis Decoder Manual](https://github.com/euroargodev/Coriolis-data-processing-chain-for-Argo-floats/tree/main/decArgo_doc/decoder_user_manual) for information on which parameters to include and how to populate this information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95895cdc-885a-4c7c-97c0-b43e20172492",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float_info = struct( ...\n",
+    "   \"WMO\", '6903014', ...\n",
+    "   \"PTT\", '300234068508780', ...\n",
+    "   \"FLOAT_TYPE\", 'PROVOR', ...\n",
+    "   \"DECODER_VERSION\", '5.45', ...\n",
+    "   \"DECODER_ID\", '212', ...\n",
+    "   \"FRAME_LENGTH\", '31', ...\n",
+    "   \"CYCLE_LENGTH\", '24', ...\n",
+    "   \"DRIFT_SAMPLING_PERIOD\", '1', ...\n",
+    "   \"DELAI\", '-1', ...\n",
+    "   \"LAUNCH_DATE\", '20001014060200', ...\n",
+    "   \"LAUNCH_LON\", '-4.626', ...\n",
+    "   \"LAUNCH_LAT\", '36.354', ...\n",
+    "   \"END_DECODING_DATE\", '20241109000000', ...\n",
+    "   \"REFERENCE_DAY\", '20201014', ...\n",
+    "   \"DM_FLAG\", '0' ...\n",
+    ");\n",
+    "\n",
+    "meta_info = struct( ...\n",
+    "    \"ARGO_USER_MANUAL_VERSION\", '3.1', ...\n",
+    "    \"PLATFORM_NUMBER\", '6903014', ...\n",
+    "    \"PTT\", '850878', ...\n",
+    "    \"IMEI\", '300234068508780', ...\n",
+    "    \"TRANS_SYSTEM\", struct( ...\n",
+    "        \"TRANS_SYSTEM_1\", 'IRIDIUM' ...\n",
+    "    ) ...\n",
+    "    % add further metadata information\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6eb3b863-fb34-419a-bb0e-565b59fbffcc",
+   "metadata": {},
+   "source": [
+    "# Float configuration and metadata - Option 2: Load from file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da411872-588b-4c45-860d-2a0ec5e6e1b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float_info = jsondecode(fileread(fullfile(float_info_dir, \"float_info.json\")));\n",
+    "meta_info  = jsondecode(fileread(fullfile(float_info_dir, \"meta_info.json\")));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e383a0e-9d6b-4900-ab92-3e639fac7245",
+   "metadata": {},
+   "source": [
+    "# Decoder Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "743ef377-9220-4f13-af74-be2e47590338",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extra_args = struct( ...\n",
+    "    \"DIR_OUTPUT_XML_FILE\", \"/mnt/data/output/xml/\" ...\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9d6bb3c0-01fa-4792-a4c7-dbfaf05e98af",
    "metadata": {},
    "source": [
-    "# Load float metadata"
+    "# Construct Request Metadata"
    ]
   },
   {
@@ -109,16 +201,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "float_info = jsondecode(fileread(fullfile(float_info_dir, \"float_info.json\")));\n",
-    "meta_info  = jsondecode(fileread(fullfile(float_info_dir, \"meta_info.json\")));\n",
-    "\n",
-    "extra_args = struct( ...\n",
-    "    \"DIR_OUTPUT_XML_FILE\", \"/mnt/data/output/xml/\" ...\n",
-    ");\n",
-    "\n",
     "float_metadata = jsonencode(struct( ...\n",
     "    \"float_info\", float_info, ...\n",
-    "    \"float_meta_info\", meta_info));\n",
+    "    \"float_meta_info\", meta_info ...\n",
+    "));\n",
     "configuration_override = jsonencode(extra_args);"
    ]
   },

--- a/jupyter/examples/notebooks/decoder.ipynb
+++ b/jupyter/examples/notebooks/decoder.ipynb
@@ -95,7 +95,7 @@
    "id": "c29118f1-b90d-4124-9de4-14254df375a0",
    "metadata": {},
    "source": [
-    "# Float Configuration and meta - Option 1: Construct manually"
+    "# Float configuration and metadata - Option 1: Construct manually"
    ]
   },
   {
@@ -139,7 +139,7 @@
    "id": "810c88e6-e412-47fa-b02e-3f9eee51b825",
    "metadata": {},
    "source": [
-    "# Float Metadata - Option 2: Load from file"
+    "# Float configuration and metadata - Option 2: Load from file"
    ]
   },
   {

--- a/jupyter/examples/notebooks/decoder.ipynb
+++ b/jupyter/examples/notebooks/decoder.ipynb
@@ -53,7 +53,7 @@
    "id": "600b0077-fc14-4231-8bcf-89debf9e583a",
    "metadata": {},
    "source": [
-    "# Set file paths and WMONUM"
+    "# Set source file path and WMONUM"
    ]
   },
   {
@@ -64,8 +64,6 @@
    "outputs": [],
    "source": [
     "file_dir = r\"/home/jovyan/examples/data/6902892_raw\"\n",
-    "float_info = r\"/home/jovyan/examples/floats_meta/6902892/float_info.json\"\n",
-    "meta_info = r\"/home/jovyan/examples/floats_meta/6902892/meta_info.json\"\n",
     "wmonum = \"6902892\""
    ]
   },
@@ -97,7 +95,51 @@
    "id": "c29118f1-b90d-4124-9de4-14254df375a0",
    "metadata": {},
    "source": [
-    "# Load float metadata"
+    "# Float Configuration and meta - Option 1: Construct manually"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a458fa32-a0e1-49b1-aeb7-b634737b46b0",
+   "metadata": {},
+   "source": [
+    "See the [Coriolis Decoder Manual](https://github.com/euroargodev/Coriolis-data-processing-chain-for-Argo-floats/tree/main/decArgo_doc/decoder_user_manual) for information on which parameters to include and how to populate this information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aba1c7bd-5291-48ab-8628-3d452789d349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float_info = {\n",
+    "    \"WMO\": \"6903014\",\n",
+    "    \"PTT\": \"300234068508780\",\n",
+    "    \"FLOAT_TYPE\": \"PROVOR\",\n",
+    "    # add further float configuration information\n",
+    "}\n",
+    "\n",
+    "meta_info = {\n",
+    "    \"ARGO_USER_MANUAL_VERSION\": \"3.1\",\n",
+    "    \"PLATFORM_NUMBER\": \"6903014\",\n",
+    "    \"PTT\": \"850878\",\n",
+    "    \"IMEI\": \"300234068508780\",\n",
+    "    # add further metadata information\n",
+    "}\n",
+    "\n",
+    "float_metadata = {\n",
+    "    \"float_info\": float_info,\n",
+    "    \"float_meta_info\": meta_info\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "810c88e6-e412-47fa-b02e-3f9eee51b825",
+   "metadata": {},
+   "source": [
+    "# Float Metadata - Option 2: Load from file"
    ]
   },
   {
@@ -107,21 +149,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "float_info = r\"/home/jovyan/examples/floats_meta/6902892/float_info.json\"\n",
+    "meta_info = r\"/home/jovyan/examples/floats_meta/6902892/meta_info.json\"\n",
+    "\n",
     "with open(float_info) as file:\n",
     "   float_info = json.loads(file.read())\n",
     "\n",
     "with open(meta_info) as file:\n",
     "   meta_info = json.loads(file.read())\n",
     "\n",
-    "# Example Extra args, used to pass to the decoder and overwrite the default configuration.\n",
-    "extra_args = {\"DIR_OUTPUT_XML_FILE\" : \"/mnt/data/output/xml/\",}\n",
-    "\n",
-    "meta_data = {\n",
-    "    \"float_metadata\": json.dumps({\n",
-    "        \"float_info\": float_info,\n",
-    "        \"float_meta_info\": meta_info,\n",
-    "    }),\n",
-    "     \"configuration_override\": json.dumps(extra_args),  # optional\n",
+    "float_metadata = {\n",
+    "    \"float_info\": float_info,\n",
+    "    \"float_meta_info\": meta_info\n",
     "}"
    ]
   },
@@ -130,7 +169,47 @@
    "id": "4a79178e-30eb-4c48-8a74-36c1bb3b2ef7",
    "metadata": {},
    "source": [
-    "# Open files and send request to decoder API"
+    "# Decoder Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa0c7a95-ac05-4aed-aca0-4a99b9391997",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example extra args, used to pass to the decoder and overwrite the default configuration.\n",
+    "extra_args = {\"DIR_OUTPUT_XML_FILE\" : \"/mnt/data/output/xml/\",}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bb74b2c-b98b-450d-8a81-513853eb5689",
+   "metadata": {},
+   "source": [
+    "# Construct Request Metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b22856d-7160-4124-96aa-903645733966",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta_data = {\n",
+    "    \"float_metadata\": json.dumps(float_metadata),\n",
+    "    \"configuration_override\": json.dumps(extra_args),  # optional\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fe62246-40e3-4289-a1ca-3411ddffdc62",
+   "metadata": {},
+   "source": [
+    "# Open files and send request to Decoder API"
    ]
   },
   {
@@ -309,14 +388,6 @@
     "plt.title(f'T–S Diagram Profile {profile_id}')\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "228048e0-f0e4-4aff-9a93-ad9a0b882a3f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Added information to Decoder readme and Python notebook.
I tried using some other parameters in the additional decoder configuration sent in configuration_override but couldn't get them to work. I tested a few options such as GENERATE_NC_META, TEST015_GREY_LIST and DIR_OUTPUT_CSV_FILE but only got a valid ZIP file back with DIR_OUTPUT_XML_FILE (which is unused according to the Decoder user manual https://github.com/euroargodev/Coriolis-data-processing-chain-for-Argo-floats/tree/main/decArgo_doc/decoder_user_manual )